### PR TITLE
Luminance support and general connection improvements

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const Homey = require('homey');
+const semaphore = require('/lib/Semaphore.js');
+const AT = require('/lib/airthings.js');
 const bufferpack = require('/lib/bufferpack.js');
 
 /*
@@ -12,285 +14,102 @@ const bufferpack = require('/lib/bufferpack.js');
 
 	modules in use so far:
 	- https://github.com/ryanrolds/bufferpack
-
-
+	- https://github.com/Wizcorp/locks
 
 */
 
 class AirthingsApp extends Homey.App {
 	
 	async onInit() {
-		this.log('AirthingsApp is running...!');
-		
+		this.log('AirthingsApp is running');
+		this.bleAccess = new semaphore(2);
 	}
 
-	getWaveValues(macAddress, pollTimeout) {
-		return new Promise(async(resolve, reject) => {
-
-			this.log(macAddress)
-			this.log(pollTimeout)
-
-			let timeout = pollTimeout;
-
-			const ble = Homey.ManagerBLE;
-
-			try {
-				this.log('Searching for: !',macAddress);
-				const advertisement = await ble.find(macAddress, timeout);
-				this.log('Found: !',macAddress);
-				await this.sleep(1000);
-				
-				const peripheral = await advertisement.connect();
-				await this.sleep(1000);
-				this.log('Connected !',macAddress);
-				const services = await peripheral.discoverAllServicesAndCharacteristics();
-				this.log('Services Discovered !',macAddress);
-				const dataService = await services.find(service => service.uuid === "b42e1f6eade711e489d3123b93f75cba");
-				const characteristics = await dataService.discoverCharacteristics();
-				
-				//Radon Short Term Average
-				const staDataChar = await characteristics.find(characteristic => characteristic.uuid === "b42e01aaade711e489d3123b93f75cba");
-				const staData = await staDataChar.read();
-				
-				//Radon Long Term Average
-				const ltaDataChar = await characteristics.find(characteristic => characteristic.uuid === "b42e0a4cade711e489d3123b93f75cba"); 
-				const ltaData = await ltaDataChar.read();
-
-				//Temperature
-				const tempDataChar = await characteristics.find(characteristic => characteristic.uuid === "2a6e");
-				const tempData = await tempDataChar.read();
-
-				//Humidity
-				const humDataChar = await characteristics.find(characteristic => characteristic.uuid === "2a6f");
-				const humData = await humDataChar.read();
-
-				//ALS + Light
-				const alsDataChar = await characteristics.find(characteristic => characteristic.uuid == "b42e1096ade711e489d3123b93f75cba")
-				const alsData = await alsDataChar.read();
-
-				await peripheral.disconnect();
-
-				const format = "<h";
-				const sensorSTA = bufferpack.unpack(format, staData)[0];
-				const sensorLTA = bufferpack.unpack(format, ltaData)[0];
-				const sensorTemperature = bufferpack.unpack(format, tempData)[0];
-				const sensorHumidity = bufferpack.unpack(format, humData)[0];
-				const formatTwo = "<B";
-				const sensorLight = bufferpack.unpack(formatTwo, alsData)[0] & 0xf0;
-
-
-				// This is the matching format for the binary data for unpacking.
-				//const format = "<xbxbHHHHHHxxxx";
-				//const unpacked = bufferpack.unpack(format, sensorData);
-
-				// Sensordata unpacked looks like this:
-				// (humidity, light, sh_rad, lo_rad, temp, pressure, co2, voc)
-				// Example:
-				// [ 81, 0, 10, 0, 2387, 48689, 366, 116 ]
-				// Some of the values requires minor math to get correct values
-				
-				let sensorValues = {
-					humidity: sensorHumidity / 100,
-					light: sensorLight,
-					shortTermRadon: sensorSTA,
-					longTermRadon: sensorLTA,
-					temperature: sensorTemperature / 100,
-				}
-				
-				resolve(sensorValues)
-
-			} catch (error) {
-				reject(error)
-			}
-			
-		})
-	}
-	getWavePlusValues(macAddress, pollTimeout) {
-		return new Promise(async(resolve, reject) => {
-
-			this.log(macAddress)
-			this.log(pollTimeout)
-
-			let timeout = pollTimeout;
-
-			const ble = Homey.ManagerBLE;
-
-			try {
-				await this.sleep(10000);
-				const advertisement = await ble.find(macAddress, timeout);
-				const peripheral = await advertisement.connect();
-				this.log('Connected !',macAddress);
-				const services = await peripheral.discoverAllServicesAndCharacteristics();
-				this.log('Services Discovered !',macAddress);
-				const dataService = await services.find(service => service.uuid === "b42e1c08ade711e489d3123b93f75cba");
-				const characteristics = await dataService.discoverCharacteristics();
-				const data = await characteristics.find(characteristic => characteristic.uuid === "b42e2a68ade711e489d3123b93f75cba");
-				const sensorData = await data.read();
-				await peripheral.disconnect();
-
-				// This is the matching format for the binary data for unpacking.
-				const format = "<xBBxHHHHHHxxxx";
-				const unpacked = bufferpack.unpack(format, sensorData);
-
-				// Sensordata unpacked looks like this:
-				// (humidity, light, sh_rad, lo_rad, temp, pressure, co2, voc)
-				// Example:
-				// [ 81, 0, 10, 0, 2387, 48689, 366, 116 ]
-				// Some of the values requires minor math to get correct values
-
-				let sensorValues = {
-					humidity: unpacked[0] / 2,
-					light: unpacked[1],
-					shortTermRadon: unpacked[2],
-					longTermRadon: unpacked[3],
-					temperature: unpacked[4] / 100,
-					pressure: unpacked[5] / 50,
-					co2: unpacked[6],
-					voc: unpacked[7]
-				}
-
-				resolve(sensorValues)
-
-			} catch (error) {
-				reject(error)
-			}
-			
-		})
-	}
-	getWaveMiniValues(macAddress, pollTimeout) {
-		return new Promise(async(resolve, reject) => {
-
-			this.log(macAddress)
-			this.log(pollTimeout)
-
-			let timeout = pollTimeout;
-
-			const ble = Homey.ManagerBLE;
-
-			try {
-				await this.sleep(5000);
-				const advertisement = await ble.find(macAddress, timeout);
-				const peripheral = await advertisement.connect();
-				this.log('Connected To Mini !',macAddress);
-				const services = await peripheral.discoverAllServicesAndCharacteristics();
-				this.log('Services Discovered Mini !',macAddress);
-				const dataService = await services.find(service => service.uuid === "b42e3882ade711e489d3123b93f75cba");
-				const characteristics = await dataService.discoverCharacteristics();
-				const data = await characteristics.find(characteristic => characteristic.uuid === "b42e3b98ade711e489d3123b93f75cba");
-				const sensorData = await data.read();
-				await peripheral.disconnect();
-				this.log('Disconnected from Mini, parsing data');
-				// This is the matching format for the binary data for unpacking.
-				const format = "<HHHHHHxxxx";
-				const unpacked = bufferpack.unpack(format, sensorData);
-
-				// Sensordata unpacked looks like this:
-				// (humidity, light, sh_rad, lo_rad, temp, pressure, co2, voc)
-				// Example:
-				// [ 81, 0, 10, 0, 2387, 48689, 366, 116 ]
-				// Some of the values requires minor math to get correct values
-
-				let sensorValues = {
-					humidity: unpacked[3] / 100,
-					light: unpacked[0],
-					temperature: (unpacked[1] / 100) - 273.15, //In Kelvin on Mini
-					pressure: unpacked[2] / 50,
-					voc: unpacked[4]
-				}
-				resolve(sensorValues)
-
-			} catch (error) {
-				reject(error)
-			}
-			
-		})
-	}
 	sleep(ms){
 		return new Promise(resolve=>{
 			setTimeout(resolve,ms)
 		})
 	}
-	discoverWaveDevices(driver) {
-		return new Promise(async(resolve, reject) => {
 
-			this.log("Searching for Airthings Wave devices...")
-			const timeout = 29000;
-
-			const ble = Homey.ManagerBLE;
-
-			try {
-				let devices = [];
-				// Wave : b42e1f6eade711e489d3123b93f75cba
-				const foundDevices = await ble.discover(['b42e1f6eade711e489d3123b93f75cba'], timeout);
-
-				foundDevices.forEach(device => {
-					const format = "<xxIxx";
-					devices.push({
-						name: "Airthings Wave (" + bufferpack.unpack(format, device.manufacturerData)[0] + ")",
-						data: {
-							id: device.id,
-							uuid: device.uuid,
-							address: device.address
-						}
-					})
-				});
-
-				resolve(devices)
-			} catch (error) {
-				reject(error)
-			}
-
-		});
+	getSemaphore() {
+		return this.bleAccess;
 	}
-	discoverWavePlusDevices(driver) {
-		return new Promise(async(resolve, reject) => {
 
-			this.log("Searching for Airthings Wave Plus devices...")
-			const timeout = 29000;
+	async getValuesFromDevice(device, macAddress, pollTimeout) {
 
-			const ble = Homey.ManagerBLE;
+		let timeout = pollTimeout;
+		const ble = Homey.ManagerBLE;
+		let deviceType = device.getDriver().deviceType;
 
-			try {
-				let devices = [];
-				// Wave + : b42e1c08ade711e489d3123b93f75cba
-				const foundDevices = await ble.discover(['b42e1c08ade711e489d3123b93f75cba'], timeout);
+		try {
 
-				foundDevices.forEach(device => {
-					const format = "<xxIxx";
-					devices.push({
-						name: "Airthings Wave + (" + bufferpack.unpack(format, device.manufacturerData)[0] + ")",
-						data: {
-							id: device.id,
-							uuid: device.uuid,
-							address: device.address
-						}
-					})
-				});
-
-				resolve(devices)
-			} catch (error) {
-				reject(error)
+			// if no peripheral instance defined, define it
+			if(device.per == undefined) {
+				this.log('Searching device')
+				const adv = await ble.find(macAddress, timeout);
+				this.log('Connecting device')
+				device.per = await adv.connect();
 			}
 
-		});
+			await device.per.assertConnected();
+			this.log('Connected');
+
+			const srv = await device.per.discoverAllServicesAndCharacteristics();
+			this.log('Services discovered');
+			
+			const dataService = await srv.find(service => service.uuid === AT.getServiceUUID(deviceType));
+
+			if(dataService == undefined) { 
+				throw 'Service not found' 
+			}
+
+			const characteristics = await dataService.discoverCharacteristics();
+			this.log('Characteristics discovered');
+
+			var sensorData = [];
+			const uuidList = AT.getCharacteristicsUUID(deviceType);
+
+			for (var uuid in uuidList) {
+				const data = await characteristics.find(characteristic => characteristic.uuid === uuidList[uuid]);
+				sensorData[uuid] = await data.read();
+			}
+			this.log('Characteristics read');
+
+			await device.per.disconnect();
+			this.log('Disconnected');
+			
+			let sensorValues = AT.parseSensorData(deviceType, sensorData);
+
+			return sensorValues;
+
+		} catch(error) {
+			if(device.per != undefined) {
+				device.per.disconnect();
+				device.per = undefined;
+			}
+			
+			throw error.message;
+		}
 	}
-	discoverWaveMiniDevices(driver) {
+
+	discoverDevices(driver)
+	{
 		return new Promise(async(resolve, reject) => {
 
-			this.log("Searching for Airthings Wave Mini devices...")
+			this.log("Searching for", AT.getLongName(driver.deviceType), "devices for 30 seconds")
 			const timeout = 29000;
 
 			const ble = Homey.ManagerBLE;
 
 			try {
 				let devices = [];
-				// Wave + : b42e3882ade711e489d3123b93f75cba
-				const foundDevices = await ble.discover(['b42e3882ade711e489d3123b93f75cba'], timeout);
+
+				const foundDevices = await ble.discover([AT.getServiceUUID(driver.deviceType)], timeout);
 
 				foundDevices.forEach(device => {
 					const format = "<xxIxx";
 					devices.push({
-						name: "Airthings Wave Mini (" + bufferpack.unpack(format, device.manufacturerData)[0] + ")",
+						name: AT.getLongName(driver.deviceType) + " (" + bufferpack.unpack(format, device.manufacturerData)[0] + ")",
 						data: {
 							id: device.id,
 							uuid: device.uuid,
@@ -303,7 +122,7 @@ class AirthingsApp extends Homey.App {
 			} catch (error) {
 				reject(error)
 			}
-
+									
 		});
 	}
 }

--- a/app.json
+++ b/app.json
@@ -70,7 +70,7 @@
         "en": "bq"
       },
       "min": 0,
-      "max": 2000,
+      "max": 10000,
       "step": 1
     },
     "measure_voc": {
@@ -87,7 +87,7 @@
         "en": "ppb"
       },
       "min": 0,
-      "max": 2000,
+      "max": 4000,
       "step": 1
     }
   },
@@ -110,7 +110,8 @@
         "measure_humidity",
         "measure_pressure",
         "measure_temperature",
-        "measure_co2"
+        "measure_co2",
+        "measure_luminance"
       ],
       "pair": [
         {
@@ -136,9 +137,9 @@
               "id": "pollInterval",
               "type": "number",
               "label": {
-                "en": "Poll interval in minutes (default is 30)"
+                "en": "Poll interval in minutes (default is 10)"
               },
-              "value": 30,
+              "value": 10,
               "min": 1,
               "max": 999,
               "hint": {
@@ -175,7 +176,8 @@
       "capabilities": [
         "measure_radon",
         "measure_humidity",
-        "measure_temperature"
+        "measure_temperature",
+        "measure_luminance"
       ],
       "pair": [
         {
@@ -201,9 +203,9 @@
               "id": "pollInterval",
               "type": "number",
               "label": {
-                "en": "Poll interval in minutes (default is 30)"
+                "en": "Poll interval in minutes (default is 10)"
               },
-              "value": 30,
+              "value": 10,
               "min": 1,
               "max": 999,
               "hint": {
@@ -241,7 +243,8 @@
         "measure_voc",
         "measure_humidity",
         "measure_pressure",
-        "measure_temperature"
+        "measure_temperature",
+        "measure_luminance"
       ],
       "pair": [
         {
@@ -267,9 +270,9 @@
               "id": "pollInterval",
               "type": "number",
               "label": {
-                "en": "Poll interval in minutes (default is 30)"
+                "en": "Poll interval in minutes (default is 10)"
               },
-              "value": 30,
+              "value": 10,
               "min": 1,
               "max": 999,
               "hint": {

--- a/drivers/airthings-mini/device.js
+++ b/drivers/airthings-mini/device.js
@@ -5,49 +5,55 @@ const Homey = require('homey');
 class WaveMiniDevice extends Homey.Device {
 	
 	onInit() {
-		this.log('WaveMiniDevice has been inited');
+		this.log('WaveMiniDevice has been initialized');
 
 		const settings = this.getSettings();
 		const pollInterval = settings.pollInterval;
 		this.log(pollInterval);
 		const POLL_INTERVAL = 1000 * 60 * pollInterval; // default 30 minutes
 
+		this.per = undefined;
+
+		// migrate from previous version of the driver
+		if(!this.hasCapability("measure_luminance")) {
+			this.log("Missing luminance. Adding to the current device");
+			this.addCapability("measure_luminance");
+		}
+
         // Run poll at init
         this.poll();
 
 		setInterval(this.poll.bind(this), POLL_INTERVAL);
-
 	}
 
-	poll() {
+	async poll() {
 
-		this.log('Polling mini device...');
+		this.log('Polling device');
 
 		const macAddress = this.getData().uuid;
 		const settings = this.getSettings();
 		const pollTimeout = settings.pollTimeout;
 
-		Homey.app.getWaveMiniValues(macAddress, pollTimeout)
-			.then(result => {
-				this.log('Got Values Mini');
-				this.log(result)
-
+		Homey.app.getSemaphore().wait(async () => {
+			try {
+				let result = await Homey.app.getValuesFromDevice(this, macAddress, pollTimeout); 
+				
 				this.setCapabilityValue("measure_pressure", result.pressure);
 				this.setCapabilityValue("measure_humidity", result.humidity);
 				this.setCapabilityValue("measure_temperature", result.temperature);
 				this.setCapabilityValue("measure_voc", result.voc);
-
-				this.log("Airthings Wave Mini sensor values updated");
-
-				return Promise.resolve();
-
-			})
-			.catch(error => {
-				new Error('Cannot get value:' + error);
-			});
-	}
-
+				this.setCapabilityValue("measure_luminance", result.light);
 	
+				Homey.app.getSemaphore().signal();
+				this.log(result);
+	
+			} catch(error) {
+
+				Homey.app.getSemaphore().signal();
+				this.log(error);
+			}
+		})
+	}	
 }
 
 module.exports = WaveMiniDevice;

--- a/drivers/airthings-mini/driver.js
+++ b/drivers/airthings-mini/driver.js
@@ -5,14 +5,14 @@ const Homey = require('homey');
 class WaveMiniDriver extends Homey.Driver {
 	
 	onInit() {
-		this.log('WaveMiniDriver has been inited');
+		this.deviceType = 'WaveMini';
 	}
 
 	// This method is called when a user is adding a device
   	// and the 'list_devices' view is called
 	onPairListDevices(data, callback) {
 
-		Homey.app.discoverWaveMiniDevices(this)
+		Homey.app.discoverDevices(this)
 			.then(devices => {
 				this.log(devices)
 				callback(null, devices);

--- a/drivers/airthings-wave-plus/device.js
+++ b/drivers/airthings-wave-plus/device.js
@@ -5,50 +5,58 @@ const Homey = require('homey');
 class WavePlusDevice extends Homey.Device {
 	
 	onInit() {
-		this.log('WavePlusDevice has been inited');
+		this.log('WavePlusDevice has been initialized');
 
 		const settings = this.getSettings();
 		const pollInterval = settings.pollInterval;
 		this.log(pollInterval);
 		const POLL_INTERVAL = 1000 * 60 * pollInterval; // default 30 minutes
 
+		this.per = undefined;
+
+		// migrate from previous version of the driver
+		if(!this.hasCapability("measure_luminance")) {
+			this.log("Missing luminance. Adding to the current device");
+			this.addCapability("measure_luminance");
+		}
+
         // Run poll at init
         this.poll();
 
 		setInterval(this.poll.bind(this), POLL_INTERVAL);
-
 	}
 
 	poll() {
 
-		this.log('Polling device...');
+		this.log('Polling device');
 
 		const macAddress = this.getData().uuid;
 		const settings = this.getSettings();
 		const pollTimeout = settings.pollTimeout;
 
-		Homey.app.getWavePlusValues(macAddress, pollTimeout)
-			.then(result => {
-				this.log(result)
-
+		Homey.app.getSemaphore().wait(async () => {
+			try {
+				let result = await Homey.app.getValuesFromDevice(this, macAddress, pollTimeout); 
+				
 				this.setCapabilityValue("measure_co2", result.co2);
 				this.setCapabilityValue("measure_pressure", result.pressure);
 				this.setCapabilityValue("measure_humidity", result.humidity);
 				this.setCapabilityValue("measure_temperature", result.temperature);
 				this.setCapabilityValue("measure_voc", result.voc);
 				this.setCapabilityValue("measure_radon", result.shortTermRadon);
-
-				this.log("Airthings Wave Plus sensor values updated");
-
-				return Promise.resolve();
-
-			})
-			.catch(error => {
-				new Error('Cannot get value:' + error);
-			});
-	}
-
+				this.setCapabilityValue("measure_luminance", result.light);
 	
+				Homey.app.getSemaphore().signal();
+				this.log(result);
+	
+			} catch(error) {
+
+				Homey.app.getSemaphore().signal();
+				this.log(error);
+			}
+		})
+		
+	}
 }
 
 module.exports = WavePlusDevice;

--- a/drivers/airthings-wave-plus/driver.js
+++ b/drivers/airthings-wave-plus/driver.js
@@ -5,14 +5,14 @@ const Homey = require('homey');
 class WavePlusDriver extends Homey.Driver {
 	
 	onInit() {
-		this.log('WavePlusDriver has been inited');
+		this.deviceType = 'WavePlus';
 	}
 
 	// This method is called when a user is adding a device
   	// and the 'list_devices' view is called
 	onPairListDevices(data, callback) {
 
-		Homey.app.discoverWavePlusDevices(this)
+		Homey.app.discoverDevices(this)
 			.then(devices => {
 				this.log(devices)
 				callback(null, devices);

--- a/drivers/airthings-wave/device.js
+++ b/drivers/airthings-wave/device.js
@@ -5,47 +5,54 @@ const Homey = require('homey');
 class WaveDevice extends Homey.Device {
 	
 	onInit() {
-		this.log('WaveDevice has been inited');
+		this.log('WaveDevice has been initialized');
 
 		const settings = this.getSettings();
 		const pollInterval = settings.pollInterval;
 		this.log(pollInterval);
 		const POLL_INTERVAL = 1000 * 60 * pollInterval; // default 30 minutes
 
+		this.per = undefined;
+
+		// migrate from previous version of the driver
+		if(!this.hasCapability("measure_luminance")) {
+			this.log("Missing luminance. Adding to the current device");
+			this.addCapability("measure_luminance");
+		}
+
         // Run poll at init
         this.poll();
 
 		setInterval(this.poll.bind(this), POLL_INTERVAL);
-
 	}
-
+	
 	poll() {
 
-		this.log('Polling device...');
+		this.log('Polling device');
 
 		const macAddress = this.getData().uuid;
 		const settings = this.getSettings();
 		const pollTimeout = settings.pollTimeout;
 
-		Homey.app.getWaveValues(macAddress, pollTimeout)
-			.then(result => {
-				this.log(result)
-
+		Homey.app.getSemaphore().wait(async () => {
+			try {
+				let result = await Homey.app.getValuesFromDevice(this, macAddress, pollTimeout); 
+				
 				this.setCapabilityValue("measure_humidity", result.humidity);
 				this.setCapabilityValue("measure_temperature", result.temperature);
 				this.setCapabilityValue("measure_radon", result.shortTermRadon);
-
-				this.log("Airthings Wave sensor values updated");
-
-				return Promise.resolve();
-
-			})
-			.catch(error => {
-				new Error('Cannot get value:' + error);
-			});
-	}
-
+				this.setCapabilityValue("measure_luminance", result.light);
 	
+				Homey.app.getSemaphore().signal();
+				this.log(result);
+	
+			} catch(error) {
+
+				Homey.app.getSemaphore().signal();
+				this.log(error);
+			}
+		})
+	}	
 }
 
 module.exports = WaveDevice;

--- a/drivers/airthings-wave/driver.js
+++ b/drivers/airthings-wave/driver.js
@@ -5,14 +5,14 @@ const Homey = require('homey');
 class WaveDriver extends Homey.Driver {
 	
 	onInit() {
-		this.log('WaveDriver has been inited');
+		this.deviceType = 'Wave';
 	}
 
 	// This method is called when a user is adding a device
   	// and the 'list_devices' view is called
 	onPairListDevices(data, callback) {
 
-		Homey.app.discoverWaveDevices(this)
+		Homey.app.discoverDevices(this)
 			.then(devices => {
 				this.log(devices)
 				callback(null, devices);

--- a/lib/Semaphore.js
+++ b/lib/Semaphore.js
@@ -1,0 +1,27 @@
+function Semaphore(initialCount) {
+	this._count = initialCount || 1;
+	this._waiting = [];
+}
+
+module.exports = Semaphore;
+
+Semaphore.prototype.wait = function (cb) {
+	this._count -= 1;
+
+	if (this._count < 0) {
+		this._waiting.push(cb);
+	} else {
+		cb.call(this);
+	}
+};
+
+Semaphore.prototype.signal = function () {
+	this._count += 1;
+
+	if (this._count <= 0) {
+		var waiter = this._waiting.shift();
+		if (waiter) {
+			waiter.call(this);
+		}
+	}
+};

--- a/lib/airthings.js
+++ b/lib/airthings.js
@@ -1,0 +1,129 @@
+
+/*!
+ *  Collection of helper utilities specific to AirThings devices
+ */
+
+const bufferpack = require('/lib/bufferpack.js');
+
+function AirThings() {
+
+    var a = this;
+
+    var services = {
+        "Wave":"b42e1f6eade711e489d3123b93f75cba",
+        "WavePlus":"b42e1c08ade711e489d3123b93f75cba",
+        "WaveMini":"b42e3882ade711e489d3123b93f75cba"
+    };
+
+    var characteristics = {
+        "Wave":["b42e01aaade711e489d3123b93f75cba","b42e0a4cade711e489d3123b93f75cba","2a6e","2a6f","b42e1096ade711e489d3123b93f75cba"],
+        "WavePlus":["b42e2a68ade711e489d3123b93f75cba"],
+        "WaveMini":["b42e3b98ade711e489d3123b93f75cba"]
+    }
+
+    var longName = {
+        "Wave":"AirThings Wave",
+        "WavePlus":"AirThings Wave Plus",
+        "WaveMini":"AirThings Wave Mini"
+    }
+
+    a.decodeLuminosity = function(lx) {
+
+        const lut = [128, 134, 140, 146, 152, 159, 166, 173, 181, 189, 197, 206, 215, 225, 235, 245];
+        let ex = (lx >>> 4) & 15;
+        let result;
+
+        if(lx == 255)
+            return 65535;
+
+        if(lx < 64)
+            return lx;
+
+        result = lut[lx & 15];
+
+        if(ex > 5) {
+            result = result << (ex - 5);
+        } else if(ex < 5) {
+            result = result >>> (5 - ex);
+        }
+
+        return result;
+    }
+
+    a.getServiceUUID = function(deviceType) {
+        return services[deviceType];
+    }
+
+    a.getCharacteristicsUUID = function(deviceType) {
+        return characteristics[deviceType];
+    }
+
+    a.getLongName = function(deviceType) {
+        return longName[deviceType];
+    }
+
+    a.parseSensorData = function(deviceType, data) {
+
+        var sensorValues = {};
+
+        switch(deviceType)
+        {
+            case "Wave":
+                {
+                    const format = "<H";
+                    const sensorSTA = bufferpack.unpack(format, data[0])[0];
+                    const sensorLTA = bufferpack.unpack(format, data[1])[0];
+                    const sensorTemperature = bufferpack.unpack("<h", data[2])[0];
+                    const sensorHumidity = bufferpack.unpack(format, data[3])[0];
+                    const sensorLight = bufferpack.unpack(format, data[4])[0] & 255;
+        
+                    sensorValues = {
+                        humidity: sensorHumidity / 100,
+                        light: a.decodeLuminosity(sensorLight),
+                        shortTermRadon: sensorSTA,
+                        longTermRadon: sensorLTA,
+                        temperature: sensorTemperature / 100,
+                    }   
+                }
+                break;
+
+            case "WavePlus":
+                {
+                    let format = "<xBBxHHHHHHxxxx";
+                    let unpacked = bufferpack.unpack(format, data[0]);
+
+                    sensorValues = {
+                        humidity: unpacked[0] / 2,
+                        light: a.decodeLuminosity(unpacked[1]),
+                        shortTermRadon: unpacked[2],
+                        longTermRadon: unpacked[3],
+                        temperature: unpacked[4] / 100,
+                        pressure: unpacked[5] / 50,
+                        co2: unpacked[6],
+                        voc: unpacked[7]
+                    }
+                }
+                break;
+
+            case "WaveMini":
+                {
+                    let format = "<HHHHHHxxxx";
+                    let unpacked = bufferpack.unpack(format, data[0]);
+
+                    sensorValues = {
+                        humidity: unpacked[3] / 100,
+                        light: unpacked[0],
+                        temperature: (unpacked[1] / 100) - 273.15, //In Kelvin on Mini
+                        pressure: unpacked[2] / 50,
+                        voc: unpacked[4]
+                    }
+                }
+                break;
+        }
+
+        return sensorValues;
+    }
+
+}
+
+module.exports = new AirThings();


### PR DESCRIPTION
Hi,

I noticed that over long periods of time (days) the reads from wave devices tend to stop. When this happens, restarting the homey seems to be the only fix. I traced this back to an apparent condition where a BLE failure would not be correctly handled. 
Also, to reduce the interaction time I added synchronization to avoid too many connections to be open at the same time.
This seems to improve connection reliability especially when other homey applications that use BLE are loaded (Beacon for example).
Also I added decoding of the luminosity values on both wave and wave+. 
There is also a little bit of refactoring so that device type specific code is all in one unit and the rest is as general as possible.

Hope that at least some of these changes will turn out useful.

Cheers,
Marco.