### PR TITLE
Critical fix and general improvements

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -9,6 +9,6 @@
     "en": "Fixed readme"
   },
   "1.3.0": {
-    "en": "Extended Wave Plus driver to display more sensor readings"
+    "en": "Show the long term radon readings, show the luminance readings, mark device as unavailable if the connection is interrupted"
   }
 }

--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -7,5 +7,8 @@
   },
   "1.2.1": {
     "en": "Fixed readme"
+  },
+  "1.3.0": {
+    "en": "Extended Wave Plus driver to display more sensor readings"
   }
 }

--- a/app.js
+++ b/app.js
@@ -116,12 +116,10 @@ class AirthingsApp extends Homey.App {
 			const ble = Homey.ManagerBLE;
 
 			try {
-				await this.sleep(10000);
 				const advertisement = await ble.find(macAddress, timeout);
 				const peripheral = await advertisement.connect();
 				this.log('Connected !',macAddress);
 				const services = await peripheral.discoverAllServicesAndCharacteristics();
-				this.log('services', services);
 				this.log('Services Discovered !',macAddress);
 				const dataService = await services.find(service => service.uuid === "b42e1c08ade711e489d3123b93f75cba");
 				const characteristics = await dataService.discoverCharacteristics();
@@ -138,8 +136,6 @@ class AirthingsApp extends Homey.App {
 				// Example:
 				// [ 81, 0, 10, 0, 2387, 48689, 366, 116 ]
 				// Some of the values requires minor math to get correct values
-
-				this.log('unpacked', unpacked);
 
 				let sensorValues = {
 					humidity: unpacked[0] / 2,

--- a/app.js
+++ b/app.js
@@ -41,6 +41,7 @@ class AirthingsApp extends Homey.App {
 				await this.sleep(1000);
 				
 				const peripheral = await advertisement.connect();
+				const rssi = peripheral.rssi;
 				await this.sleep(1000);
 				this.log('Connected !',macAddress);
 				const services = await peripheral.discoverAllServicesAndCharacteristics();
@@ -95,6 +96,7 @@ class AirthingsApp extends Homey.App {
 					shortTermRadon: sensorSTA,
 					longTermRadon: sensorLTA,
 					temperature: sensorTemperature / 100,
+					rssi: rssi
 				}
 				
 				resolve(sensorValues)
@@ -118,6 +120,7 @@ class AirthingsApp extends Homey.App {
 			try {
 				const advertisement = await ble.find(macAddress, timeout);
 				const peripheral = await advertisement.connect();
+				const rssi = peripheral.rssi;
 				this.log('Connected !',macAddress);
 				const services = await peripheral.discoverAllServicesAndCharacteristics();
 				this.log('Services Discovered !',macAddress);
@@ -145,7 +148,8 @@ class AirthingsApp extends Homey.App {
 					temperature: unpacked[4] / 100,
 					pressure: unpacked[5] / 50,
 					co2: unpacked[6],
-					voc: unpacked[7]
+					voc: unpacked[7],
+					rssi: rssi
 				}
 
 				resolve(sensorValues)
@@ -169,6 +173,7 @@ class AirthingsApp extends Homey.App {
 			try {
 				const advertisement = await ble.find(macAddress, timeout);
 				const peripheral = await advertisement.connect();
+				const rssi = peripheral.rssi;
 				this.log('Connected To Mini !',macAddress);
 				const services = await peripheral.discoverAllServicesAndCharacteristics();
 				this.log('Services Discovered Mini !',macAddress);
@@ -193,7 +198,8 @@ class AirthingsApp extends Homey.App {
 					light: unpacked[0],
 					temperature: (unpacked[1] / 100) - 273.15, //In Kelvin on Mini
 					pressure: unpacked[2] / 50,
-					voc: unpacked[4]
+					voc: unpacked[4],
+					rssi: rssi
 				}
 				resolve(sensorValues)
 

--- a/app.js
+++ b/app.js
@@ -30,7 +30,7 @@ class AirthingsApp extends Homey.App {
 			this.log(macAddress)
 			this.log(pollTimeout)
 
-			let timeout = pollTimeout;
+			let timeout = pollTimeout * 1000;
 
 			const ble = Homey.ManagerBLE;
 
@@ -111,7 +111,7 @@ class AirthingsApp extends Homey.App {
 			this.log(macAddress)
 			this.log(pollTimeout)
 
-			let timeout = pollTimeout;
+			let timeout = pollTimeout*1000;
 
 			const ble = Homey.ManagerBLE;
 
@@ -162,12 +162,11 @@ class AirthingsApp extends Homey.App {
 			this.log(macAddress)
 			this.log(pollTimeout)
 
-			let timeout = pollTimeout;
+			let timeout = pollTimeout*1000;
 
 			const ble = Homey.ManagerBLE;
 
 			try {
-				await this.sleep(5000);
 				const advertisement = await ble.find(macAddress, timeout);
 				const peripheral = await advertisement.connect();
 				this.log('Connected To Mini !',macAddress);

--- a/app.js
+++ b/app.js
@@ -121,6 +121,7 @@ class AirthingsApp extends Homey.App {
 				const peripheral = await advertisement.connect();
 				this.log('Connected !',macAddress);
 				const services = await peripheral.discoverAllServicesAndCharacteristics();
+				this.log('services', services);
 				this.log('Services Discovered !',macAddress);
 				const dataService = await services.find(service => service.uuid === "b42e1c08ade711e489d3123b93f75cba");
 				const characteristics = await dataService.discoverCharacteristics();
@@ -137,6 +138,8 @@ class AirthingsApp extends Homey.App {
 				// Example:
 				// [ 81, 0, 10, 0, 2387, 48689, 366, 116 ]
 				// Some of the values requires minor math to get correct values
+
+				this.log('unpacked', unpacked);
 
 				let sensorValues = {
 					humidity: unpacked[0] / 2,

--- a/app.json
+++ b/app.json
@@ -111,12 +111,6 @@
       "step": 1
     }
   },
-  "energy": {
-    "batteries": [
-      "AAA",
-      "AAA"
-    ]
-  },
   "drivers": [
     {
       "id": "airthings-wave-plus",
@@ -132,6 +126,12 @@
         "measure_temperature",
         "measure_co2"
       ],
+      "energy": {
+        "batteries": [
+          "AAA",
+          "AAA"
+        ]
+      },
       "pair": [
         {
           "id": "list_devices",
@@ -146,6 +146,26 @@
         }
       ],
       "settings": [
+        {
+          "id" : "info",
+          "type": "group",
+          "label": {
+              "en": "Info"
+          },
+          "children": [
+              {
+                  "id": "rssi",
+                  "type": "label",
+                  "label": {
+                      "en": "Signal strength"
+                  },           
+                   "hint": {
+                    "en": "lower is better"
+                  },
+                  "value": "Unknown"
+              }
+          ]
+        },
         {
           "type": "group",
           "label": {
@@ -197,6 +217,12 @@
         "measure_humidity",
         "measure_temperature"
       ],
+      "energy": {
+        "batteries": [
+          "AAA",
+          "AAA"
+        ]
+      },
       "pair": [
         {
           "id": "list_devices",
@@ -211,6 +237,26 @@
         }
       ],
       "settings": [
+        {
+          "id" : "info",
+          "type": "group",
+          "label": {
+              "en": "Info"
+          },
+          "children": [
+              {
+                  "id": "rssi",
+                  "type": "label",
+                  "label": {
+                      "en": "Signal strength"
+                  },           
+                   "hint": {
+                    "en": "lower is better"
+                  },
+                  "value": "Unknown"
+              }
+          ]
+        },
         {
           "type": "group",
           "label": {
@@ -263,6 +309,12 @@
         "measure_pressure",
         "measure_temperature"
       ],
+      "energy": {
+        "batteries": [
+          "AAA",
+          "AAA"
+        ]
+      },
       "pair": [
         {
           "id": "list_devices",
@@ -277,6 +329,26 @@
         }
       ],
       "settings": [
+        {
+          "id" : "info",
+          "type": "group",
+          "label": {
+              "en": "Info"
+          },
+          "children": [
+              {
+                  "id": "rssi",
+                  "type": "label",
+                  "label": {
+                      "en": "Signal strength"
+                  },           
+                   "hint": {
+                    "en": "lower is better"
+                  },
+                  "value": "Unknown"
+              }
+          ]
+        },
         {
           "type": "group",
           "label": {

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.airthings",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "compatibility": ">=1.5.0",
   "sdk": 2,
   "brandColor": "#e5ac00",
@@ -45,6 +45,9 @@
       {
         "name": "Airthings AS / Ole Andreas Torvmark",
         "email": "ole.torvmark@airthings.com"
+      },
+      {
+        "name": "MadMonkey87"
       }
     ]
   },
@@ -59,7 +62,24 @@
     "measure_radon": {
       "type": "number",
       "title": {
-        "en": "Radon"
+        "en": "Radon (Short Term)"
+      },
+      "icon": "/assets/radon.svg",
+      "insights": true,
+      "uiComponent": "sensor",
+      "getable": true,
+      "setable": false,
+      "units": {
+        "en": "bq"
+      },
+      "min": 0,
+      "max": 2000,
+      "step": 1
+    },
+    "measure_radon_longterm": {
+      "type": "number",
+      "title": {
+        "en": "Radon (Long Term)"
       },
       "icon": "/assets/radon.svg",
       "insights": true,

--- a/drivers/airthings-mini/device.js
+++ b/drivers/airthings-mini/device.js
@@ -3,17 +3,20 @@
 const Homey = require('homey');
 
 class WaveMiniDevice extends Homey.Device {
-	
+
 	onInit() {
 		this.log('WaveMiniDevice has been inited');
+
+		// needed if the device was created with app version <=1.2.1
+		this.addCapability("measure_luminance");
 
 		const settings = this.getSettings();
 		const pollInterval = settings.pollInterval;
 		this.log(pollInterval);
 		const POLL_INTERVAL = 1000 * 60 * pollInterval; // default 30 minutes
 
-        // Run poll at init
-        this.poll();
+		// Run poll at init
+		this.poll();
 
 		setInterval(this.poll.bind(this), POLL_INTERVAL);
 
@@ -36,6 +39,7 @@ class WaveMiniDevice extends Homey.Device {
 				this.setCapabilityValue("measure_humidity", result.humidity);
 				this.setCapabilityValue("measure_temperature", result.temperature);
 				this.setCapabilityValue("measure_voc", result.voc);
+				this.setCapabilityValue("measure_luminance", result.light);
 
 				this.log("Airthings Wave Mini sensor values updated");
 
@@ -47,7 +51,7 @@ class WaveMiniDevice extends Homey.Device {
 			});
 	}
 
-	
+
 }
 
 module.exports = WaveMiniDevice;

--- a/drivers/airthings-mini/device.js
+++ b/drivers/airthings-mini/device.js
@@ -41,10 +41,12 @@ class WaveMiniDevice extends Homey.Device {
 				this.setCapabilityValue("measure_voc", result.voc);
 				this.setCapabilityValue("measure_luminance", result.light);
 
+				this.setSettings({ rssi: result.rssi + ' db' });
+
 				this.log("Airthings Wave Mini sensor values updated");
 
 				this.setAvailable();
-				
+
 				return Promise.resolve();
 
 			})

--- a/drivers/airthings-mini/device.js
+++ b/drivers/airthings-mini/device.js
@@ -43,10 +43,13 @@ class WaveMiniDevice extends Homey.Device {
 
 				this.log("Airthings Wave Mini sensor values updated");
 
+				this.setAvailable();
+				
 				return Promise.resolve();
 
 			})
 			.catch(error => {
+				this.setUnavailable('Cannot get value:' + error);
 				new Error('Cannot get value:' + error);
 			});
 	}

--- a/drivers/airthings-wave-plus/device.js
+++ b/drivers/airthings-wave-plus/device.js
@@ -7,6 +7,10 @@ class WavePlusDevice extends Homey.Device {
 	onInit() {
 		this.log('WavePlusDevice has been inited');
 
+		// needed if the device was created with app version <=1.2.1
+		this.addCapability("measure_radon_longterm");
+		this.addCapability("measure_luminance");
+
 		const settings = this.getSettings();
 		const pollInterval = settings.pollInterval;
 		this.log(pollInterval);
@@ -29,7 +33,7 @@ class WavePlusDevice extends Homey.Device {
 
 		Homey.app.getWavePlusValues(macAddress, pollTimeout)
 			.then(result => {
-				this.log(result)
+				this.log(result);
 
 				this.setCapabilityValue("measure_co2", result.co2);
 				this.setCapabilityValue("measure_pressure", result.pressure);
@@ -37,6 +41,8 @@ class WavePlusDevice extends Homey.Device {
 				this.setCapabilityValue("measure_temperature", result.temperature);
 				this.setCapabilityValue("measure_voc", result.voc);
 				this.setCapabilityValue("measure_radon", result.shortTermRadon);
+				this.setCapabilityValue("measure_radon_longterm", result.longTermRadon);
+				this.setCapabilityValue("measure_luminance", result.light);
 
 				this.log("Airthings Wave Plus sensor values updated");
 

--- a/drivers/airthings-wave-plus/device.js
+++ b/drivers/airthings-wave-plus/device.js
@@ -46,10 +46,13 @@ class WavePlusDevice extends Homey.Device {
 
 				this.log("Airthings Wave Plus sensor values updated");
 
+				this.setAvailable();
+
 				return Promise.resolve();
 
 			})
 			.catch(error => {
+				this.setUnavailable('Cannot get value:' + error);
 				new Error('Cannot get value:' + error);
 			});
 	}

--- a/drivers/airthings-wave-plus/device.js
+++ b/drivers/airthings-wave-plus/device.js
@@ -44,6 +44,8 @@ class WavePlusDevice extends Homey.Device {
 				this.setCapabilityValue("measure_radon_longterm", result.longTermRadon);
 				this.setCapabilityValue("measure_luminance", result.light);
 
+				this.setSettings({ rssi: result.rssi + ' db' });
+
 				this.log("Airthings Wave Plus sensor values updated");
 
 				this.setAvailable();

--- a/drivers/airthings-wave/device.js
+++ b/drivers/airthings-wave/device.js
@@ -44,10 +44,13 @@ class WaveDevice extends Homey.Device {
 
 				this.log("Airthings Wave sensor values updated");
 
+				this.setAvailable();
+				
 				return Promise.resolve();
 
 			})
 			.catch(error => {
+				this.setUnavailable('Cannot get value:' + error);
 				new Error('Cannot get value:' + error);
 			});
 	}

--- a/drivers/airthings-wave/device.js
+++ b/drivers/airthings-wave/device.js
@@ -42,10 +42,12 @@ class WaveDevice extends Homey.Device {
 				this.setCapabilityValue("measure_radon", result.longTermRadon);
 				this.setCapabilityValue("measure_luminance", result.light);
 
+				this.setSettings({ rssi: result.rssi + ' db' });
+
 				this.log("Airthings Wave sensor values updated");
 
 				this.setAvailable();
-				
+
 				return Promise.resolve();
 
 			})

--- a/drivers/airthings-wave/device.js
+++ b/drivers/airthings-wave/device.js
@@ -7,6 +7,11 @@ class WaveDevice extends Homey.Device {
 	onInit() {
 		this.log('WaveDevice has been inited');
 
+		
+		// needed if the device was created with app version <=1.2.1
+		this.addCapability("measure_radon_longterm");
+		this.addCapability("measure_luminance");
+
 		const settings = this.getSettings();
 		const pollInterval = settings.pollInterval;
 		this.log(pollInterval);
@@ -34,6 +39,8 @@ class WaveDevice extends Homey.Device {
 				this.setCapabilityValue("measure_humidity", result.humidity);
 				this.setCapabilityValue("measure_temperature", result.temperature);
 				this.setCapabilityValue("measure_radon", result.shortTermRadon);
+				this.setCapabilityValue("measure_radon", result.longTermRadon);
+				this.setCapabilityValue("measure_luminance", result.light);
 
 				this.log("Airthings Wave sensor values updated");
 


### PR DESCRIPTION
- Critical fix: The timeout for reading device details was using seconds but it needs to be provided in miliseconds. This simple fix resolved all my connectivity issues
-  properly mark a device as unavailable if the connection fails
-  added capabilities for luminance and long term radon readings
-  show connection strength in the device details
- fixed a small bug in the app manifest where the energy readings were not defined in the drivers